### PR TITLE
areas_by_radius fix

### DIFF
--- a/lib/ibotta_geohash.rb
+++ b/lib/ibotta_geohash.rb
@@ -164,8 +164,9 @@ module IbottaGeohash
 
       #estimate the size of boxes to target
       steps = estimate_steps_by_radius(radius_meters)
-      #re-encode point at steps
-      hash = encode(lat, lon, steps)
+      #re-encode point using steps
+      str_len = steps*2/5
+      hash = encode(lat, lon, str_len)
 
       #get neighbors of box
       n_n, n_ne, n_e, n_se, n_s, n_sw, n_w, n_nw = nb = neighbors(hash)

--- a/spec/ibotta_geohash_spec.rb
+++ b/spec/ibotta_geohash_spec.rb
@@ -145,10 +145,11 @@ describe IbottaGeohash do
   end
 
   describe "::areas_by_radius" do
-    it 'known' do
-      p area = described_class.areas_by_radius(45.37, -121.7, 50)
-      p "----------"
-      p area = described_class.areas_by_radius(45.37, -121.7, 50_000)
+    it '50 meters' do
+      expect(described_class.areas_by_radius(45.37, -121.7, 50)).to eq(['c216nek', 'c216nem'])
+    end
+    it '50 km' do
+      expect(described_class.areas_by_radius(45.37, -121.7, 50_000)).to eq(['c21', '9rc'])
     end
     it 'random' do
       1024.times do
@@ -162,7 +163,12 @@ describe IbottaGeohash do
   end
 
   describe "::estimate_steps_by_radius" do
-    it 'known'
+    it '50 meters' do
+      expect(described_class.estimate_steps_by_radius(50)).to eq(19)
+    end
+    it '50 km' do
+      expect(described_class.estimate_steps_by_radius(50_000)).to eq(9)
+    end
     it 'random' do
       1024.times do
         steps = described_class.estimate_steps_by_radius(rand(1..900_000))


### PR DESCRIPTION
`areas_by_radius` was calculating the geohash string using the steps as if it were the string length, but the string length is not the same as the steps. However, it is directly proportional, therefore, the value is easily converted by the formula `str_len = steps*2/5`. This will automatically round down the value, which works because shorter length geohash means a bigger range for latitude and longitude, and thus a bigger area.
